### PR TITLE
Remove deals API calls to prevent Lotus crash

### DIFF
--- a/plugins/inputs/lotus/lotus.go
+++ b/plugins/inputs/lotus/lotus.go
@@ -76,13 +76,11 @@ func (s *LotusInput) Gather(acc telegraf.Accumulator) error {
 	}
 
 	measurements := map[string]interface{}{
-		"epoch":          daemonMetrics.Status.SyncStatus.Epoch,
-		"behind":         daemonMetrics.Status.SyncStatus.Behind,
-		"messagePeers":   daemonMetrics.Status.PeerStatus.PeersToPublishMsgs,
-		"blockPeers":     daemonMetrics.Status.PeerStatus.PeersToPublishBlocks,
-		"marketDeals":    len(minerMetrics.MarketDeals),
-		"retrievalDeals": len(minerMetrics.RetrievalDeals),
-		"balance":        daemonMetrics.Balance}
+		"epoch":        daemonMetrics.Status.SyncStatus.Epoch,
+		"behind":       daemonMetrics.Status.SyncStatus.Behind,
+		"messagePeers": daemonMetrics.Status.PeerStatus.PeersToPublishMsgs,
+		"blockPeers":   daemonMetrics.Status.PeerStatus.PeersToPublishBlocks,
+		"balance":      daemonMetrics.Balance}
 
 	sectorsTotal := 0
 	for sectorState, count := range minerMetrics.SectorSummary {

--- a/plugins/inputs/lotus/miner.go
+++ b/plugins/inputs/lotus/miner.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	jsonrpc "github.com/filecoin-project/go-jsonrpc"
 	lotusapi "github.com/filecoin-project/lotus/api"
 	"github.com/filecoin-project/lotus/extern/sector-storage/fsutil"
@@ -23,11 +22,6 @@ func (m Miner) FetchMetrics() MinerMetrics {
 	sectorSummary, err := m.api.SectorsSummary(context.Background())
 	if err != nil {
 		log.Printf("calling sectors summary: %s", err)
-	}
-
-	marketDeals, err := m.api.MarketListDeals(context.Background())
-	if err != nil {
-		log.Printf("calling MarketListDeals: %s", err)
 	}
 
 	workerStats, err := m.api.WorkerStats(context.Background())
@@ -54,7 +48,6 @@ func (m Miner) FetchMetrics() MinerMetrics {
 	}
 	return MinerMetrics{
 		SectorSummary: sectorSummary,
-		MarketDeals:   marketDeals,
 		WorkerStats:   workerStats,
 		WorkerJobs:    workerJobs,
 		StorageStats:  storageStats,
@@ -84,10 +77,8 @@ func NewMiner(addr string, token string) (*Miner, error) {
 }
 
 type MinerMetrics struct {
-	WorkerJobs     map[uuid.UUID][]storiface.WorkerJob
-	WorkerStats    map[uuid.UUID]storiface.WorkerStats
-	StorageStats   map[stores.ID]fsutil.FsStat
-	SectorSummary  map[lotusapi.SectorState]int
-	MarketDeals    []lotusapi.MarketDeal
-	RetrievalDeals []retrievalmarket.ProviderDealState
+	WorkerJobs    map[uuid.UUID][]storiface.WorkerJob
+	WorkerStats   map[uuid.UUID]storiface.WorkerStats
+	StorageStats  map[stores.ID]fsutil.FsStat
+	SectorSummary map[lotusapi.SectorState]int
 }


### PR DESCRIPTION
Remove deals API calls to Lotus Miner. The issue is that whatever Lotus Miner does when handling those calls makes Lotus daemon leak memory indefinitely and crash.

Resolves https://linear.app/alt-labs/issue/DEV-405/miner-metrics-are-not-collected-because-of-some-problems-with-lotus